### PR TITLE
salt deletion

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -103,12 +103,10 @@ class APIController extends Controller
 
         //hashing options
         $options = [
-            'cost' => '10',
-            'salt' => openssl_random_pseudo_bytes(22)
+            'cost' => '11',
         ];
 
-        $activationSalt = md5('livesite');
-        $activationString = md5(microtime().$userInput['email'].openssl_random_pseudo_bytes(60), FALSE).$activationSalt;
+        $activationString = md5(microtime().$userInput['email'].openssl_random_pseudo_bytes(60), FALSE);
 
         $defaultUserValues = [
             'is_activated' => 'false',

--- a/database/seeds/UserSeed.php
+++ b/database/seeds/UserSeed.php
@@ -20,7 +20,6 @@ class UserSeed extends Seeder
          */
         $options = [
             'cost' => '11',
-            'salt' => openssl_random_pseudo_bytes(22)
         ];
 
         $activationSalt = md5('livesite');
@@ -42,7 +41,7 @@ class UserSeed extends Seeder
                 'email' => $faker->safeEmail,
                 'password' => password_hash('secret', PASSWORD_BCRYPT, $options),
                 'full_name' => $faker->name,
-                'activation_token' => password_hash($faker->safeEmail, PASSWORD_BCRYPT).$activationSalt
+                'activation_token' => password_hash($faker->safeEmail, PASSWORD_BCRYPT)
             ];
 
             User::create($seed);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25553631/52908375-edb15c00-32af-11e9-8848-3da99f8299d7.png)

> Yes, there's a solution - don't use the 'salt' option.
> 
> You don't need to salt manually, PHP does that automatically for you.
> 
> It's not an option to add salt, but to replace the would-be-generated one, and under no circumstances would you be able to provide a better salt - that's why it's deprecated.

source: https://stackoverflow.com/questions/40351479/php-salt-option-to-password-hash-is-deprecated